### PR TITLE
Automatic build and deploy to S3

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,16 +1,39 @@
 name: build-and-deploy
+# Largely built off of sample from: https://docs.github.com/en/actions/deployment/
+# security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
 on:
   push:
     branches:
       - test-workflows
+env:
+  BUCKET_NAME : "co-obh-public-dir-test"
+  AWS_REGION : "us-east-1"
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
+    # Get JWT token from GitHub's OIDC provider
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - name: Clone the repo
+        uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v2
         with:
           node-version: '16'
-      - run: npm install -g gatsby-cli
-      - run: npm install
-      - run: gatsby build
+      - name: Install Gatsby CLI
+        run: npm install -g gatsby-cli
+      - name: npm install
+        run: npm install
+      - name: gatsby build
+        run: gatsby build
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::731870575956:role/CO-OBH-PublicDirectoryOIDC
+          role-session-name: CO-OBH-Public-Dir-Push
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Copy /public folder to s3
+        run: |
+          aws s3 cp ./public s3://${{ env.BUCKET_NAME }}/ --recursive

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,10 +1,11 @@
-name: build-and-deploy
+# Automatic build and deploy on any push to main.
 # Largely built off of sample from: https://docs.github.com/en/actions/deployment/
 # security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
+name: build-and-deploy
 on:
   push:
     branches:
-      - test-workflows
+      - main
 env:
   BUCKET_NAME : "co-obh-public-directory"
   AWS_REGION : "us-east-1"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - test-workflows
 env:
-  BUCKET_NAME : "co-obh-public-dir-test"
+  BUCKET_NAME : "co-obh-public-directory"
   AWS_REGION : "us-east-1"
 jobs:
   build-and-deploy:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,16 @@
+name: build-and-deploy
+on:
+  push:
+    branches:
+      - test-workflows
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - run: npm install -g gatsby-cli
+      - run: npm install
+      - run: gatsby build

--- a/.github/workflows/run-test-build.yml
+++ b/.github/workflows/run-test-build.yml
@@ -1,0 +1,15 @@
+# Runs on any new commit or commits pushed to any branch. Intended for testing new 
+# changes before merging to master (build status will show next to commit).
+name: run-test-build
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - run: npm install -g gatsby-cli
+      - run: npm install
+      - run: gatsby build


### PR DESCRIPTION
Once this is merged every time a change is made to master an automatic build and deploy to S3 will occur, updating the public directory static site.

I think these workflows are ready to be merged into master for 1) actual practical use and 2) thorough testing for this feature as we create update our website.

`build-and-deploy.yml` includes the automatic build and deploy workflows, that I've tested and have shown to build from this repo successfully and push to S3. It uses OpenID Connect to authenticate with AWS. The IAM role in use is configured to **only allow changes from the master branch on this repo**.

`run-test-build.yml` runs a build on every commit so that we can see the little checkmark and X next to each commit showing the build status as we push them.

Does not include a staging area.
