### PR TITLE
make bucket info secret

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -9,6 +9,7 @@ on:
 env:
   BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
   AWS_REGION: ${{ secrets.AWS_REGION }}
+  ROLE_ARN: ${{ secrets.AWS_BUCKET_PUSH_ROLE_ARN }}
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -32,7 +33,7 @@ jobs:
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::731870575956:role/CO-OBH-PublicDirectoryOIDC
+          role-to-assume: ${{ env.ROLE_ARN }}
           role-session-name: CO-OBH-Public-Dir-Push
           aws-region: ${{ env.AWS_REGION }}
       - name: Copy /public folder to s3

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,7 +5,7 @@ name: build-and-deploy
 on:
   push:
     branches:
-      - main
+      - ad/make-bucket-info-secret
 env:
   BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
   AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,10 +5,10 @@ name: build-and-deploy
 on:
   push:
     branches:
-      - main
+      - ad/make-bucket-info-secret
 env:
-  BUCKET_NAME : "co-obh-public-directory"
-  AWS_REGION : "us-east-1"
+  BUCKET_NAME : ${{ secrets.S3_BUCKET_NAME }}
+  AWS_REGION : ${{ secrets.AWS_REGION }}
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,7 +5,7 @@ name: build-and-deploy
 on:
   push:
     branches:
-      - ad/make-bucket-info-secret
+      - main
 env:
   BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
   AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -7,8 +7,8 @@ on:
     branches:
       - ad/make-bucket-info-secret
 env:
-  BUCKET_NAME : ${{ secrets.S3_BUCKET_NAME }}
-  AWS_REGION : ${{ secrets.AWS_REGION }}
+  BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+  AWS_REGION: ${{ secrets.AWS_REGION }}
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Small change. Instead of having them displayed in plain text in the code we might as well make the bucket name and AWS region secrets.

~~Still needs to be tested after we get billing sorted out (currently all Actions get an error "The job was not started because recent account payments have failed...").~~ Tested and ready to merge.