### PR TITLE
UCRs Endpoint Workflow

### DIFF
--- a/.github/workflows/get-then-push-data.yml
+++ b/.github/workflows/get-then-push-data.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::731870575956:role/CO-OBH-PublicDirectoryOIDC
+          role-to-assume: ${{ secrets.AWS_BUCKET_PUSH_ROLE_ARN }}
           role-session-name: CO-OBH-Public-Dir-Push
           aws-region: ${{ env.AWS_REGION }}
       - name: Copy data file to s3

--- a/.github/workflows/get-then-push-data.yml
+++ b/.github/workflows/get-then-push-data.yml
@@ -14,9 +14,8 @@ env:
   BUCKET_NAME : ${{ secrets.S3_BUCKET_NAME }}
   AWS_REGION : ${{ secrets.AWS_REGION }}
   HQ_API_KEY : ${{ secrets.ADDISONS_TEST_HQ_API_KEY }}
-  REPORT_URL : https://www.commcarehq.org/a/${{secrets.PROJECT_NAME}}/api/v0.5/configurablereportdata/${{secrets.REPORT_ID}}
 jobs:
-  build-and-deploy:
+  get-data-then-push:
     runs-on: ubuntu-latest
     # Get JWT token from GitHub's OIDC provider
     permissions:
@@ -25,7 +24,7 @@ jobs:
     steps:
       - name: Get data from the HQ API
         run: |
-          curl -H "Authorization: ApiKey ${{ secrets.ADDISONS_TEST_API_USERNAME }}:${{ secrets.ADDISONS_TEST_HQ_API_KEY }}" '${{env.REPORT_URL}}' >> directory_data.json
+          curl -H "Authorization: ApiKey ${{ secrets.ADDISONS_TEST_API_USERNAME }}:${{ secrets.ADDISONS_TEST_HQ_API_KEY }}" 'https://www.commcarehq.org/a/${{ secrets.PROJECT_NAME }}/api/v0.5/configurablereportdata/${{ secrets.REPORT_ID }}/' >> directory_data.json
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/get-then-push-data.yml
+++ b/.github/workflows/get-then-push-data.yml
@@ -3,13 +3,9 @@
 # occurs via an API key, while authentication with AWS happens via OIDC.
 name: get-then-push-data
 on:
-  # schedule:
-  # Run at 12:30AM, 3:30 AM, 6:30 AM... every day
-  #   - cron: '30 0,3,6,9,12,15,18,21 * * 1,3'
-  #   - cron: '30 5 * * 2,4'
-  push:
-    branches:
-      - ad/ucrs-endpoint-workflow
+  schedule:
+  # Run every 3 hours at 1:30AM, 4:30 AM, 7:30 AM... every day
+    - cron: '30 1,4,7,10,13,16,19,22 * * *'
 env:
   BUCKET_NAME : ${{ secrets.S3_BUCKET_NAME }}
   AWS_REGION : ${{ secrets.AWS_REGION }}

--- a/.github/workflows/get-then-push-data.yml
+++ b/.github/workflows/get-then-push-data.yml
@@ -1,0 +1,37 @@
+# Automated pull of data needed for the public directory from an HQ UCR API endpoint.
+# Data is pushed to S3 bucket for use by the static site. Authentication with HQ
+# occurs via an API key, while authentication with AWS happens via OIDC.
+name: get-then-push-data
+on:
+  # schedule:
+  # Run at 12:30AM, 3:30 AM, 6:30 AM... every day
+  #   - cron: '30 0,3,6,9,12,15,18,21 * * 1,3'
+  #   - cron: '30 5 * * 2,4'
+  push:
+    branches:
+      - ad/ucrs-endpoint-workflow
+env:
+  BUCKET_NAME : ${{ secrets.S3_BUCKET_NAME }}
+  AWS_REGION : ${{ secrets.AWS_REGION }}
+  HQ_API_KEY : ${{ secrets.ADDISONS_TEST_HQ_API_KEY }}
+  REPORT_URL : https://www.commcarehq.org/a/${{secrets.PROJECT_NAME}}/api/v0.5/configurablereportdata/${{secrets.REPORT_ID}}
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    # Get JWT token from GitHub's OIDC provider
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Get data from the HQ API
+        run: |
+          curl "Authorization: ApiKey ${{ secrets.ADDISONS_TEST_API_USERNAME }}:${{ secrets.ADDISONS_TEST_HQ_API_KEY }}" '${{env.REPORT_URL}}' >> directory_data.json
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::731870575956:role/CO-OBH-PublicDirectoryOIDC
+          role-session-name: CO-OBH-Public-Dir-Push
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Copy /public folder to s3
+        run: |
+          aws s3 cp directory_data.json s3://${{ env.BUCKET_NAME }}/

--- a/.github/workflows/get-then-push-data.yml
+++ b/.github/workflows/get-then-push-data.yml
@@ -24,7 +24,8 @@ jobs:
     steps:
       - name: Get data from the HQ API
         run: |
-          curl -H "Authorization: ApiKey ${{ secrets.ADDISONS_TEST_API_USERNAME }}:${{ secrets.ADDISONS_TEST_HQ_API_KEY }}" 'https://www.commcarehq.org/a/${{ secrets.PROJECT_NAME }}/api/v0.5/configurablereportdata/${{ secrets.REPORT_ID }}/' >> directory_data.json
+          curl -H "Authorization: ApiKey ${{ secrets.ADDISONS_TEST_API_USERNAME }}:${{ secrets.ADDISONS_TEST_HQ_API_KEY }}" \
+          'https://www.commcarehq.org/a/${{ secrets.PROJECT_NAME }}/api/v0.5/configurablereportdata/${{ secrets.REPORT_ID }}/' >> directory_data.json
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/get-then-push-data.yml
+++ b/.github/workflows/get-then-push-data.yml
@@ -25,13 +25,13 @@ jobs:
     steps:
       - name: Get data from the HQ API
         run: |
-          curl "Authorization: ApiKey ${{ secrets.ADDISONS_TEST_API_USERNAME }}:${{ secrets.ADDISONS_TEST_HQ_API_KEY }}" '${{env.REPORT_URL}}' >> directory_data.json
+          curl -H "Authorization: ApiKey ${{ secrets.ADDISONS_TEST_API_USERNAME }}:${{ secrets.ADDISONS_TEST_HQ_API_KEY }}" '${{env.REPORT_URL}}' >> directory_data.json
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::731870575956:role/CO-OBH-PublicDirectoryOIDC
           role-session-name: CO-OBH-Public-Dir-Push
           aws-region: ${{ env.AWS_REGION }}
-      - name: Copy /public folder to s3
+      - name: Copy data file to s3
         run: |
           aws s3 cp directory_data.json s3://${{ env.BUCKET_NAME }}/


### PR DESCRIPTION
This workflow automatically pulls data from a test [reports endpoint](https://confluence.dimagi.com/display/commcarepublic/Download+Report+Data) (on an "addison-test" domain) and pushes it to the S3 bucket.

It is set to run on a schedule every 3 hours, following the [cron syntax](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07). 